### PR TITLE
BUGFIX: Add typscript to dev dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,12 @@
           "dev": true
         }
       }
+    },
+    "typescript": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   },
   "homepage": "https://github.com/jcramer/grpc-bchrpc-web#readme",
   "devDependencies": {
-    "ts-protoc-gen": "^0.10.0"
+    "ts-protoc-gen": "^0.10.0",
+    "typescript": "^3.7.2"
   },
   "dependencies": {
     "@improbable-eng/grpc-web": "^0.9.6",


### PR DESCRIPTION
These dependencies are required for dev but missing from the list. Fixing this allows `yarn install` or `npm install` to install all the deps required to make changes to this library.